### PR TITLE
Fix incorrect argument in message_signature() function

### DIFF
--- a/python/helpers/utils.py
+++ b/python/helpers/utils.py
@@ -53,7 +53,7 @@ def message_signature(
     # k should be a strong cryptographical random
     # See: https://tools.ietf.org/html/rfc6979
     k = generate_k_rfc6979(msg_hash, priv_key, seed)
-    return rs_sign(private_key=priv_key, msg_hash=msg_hash, k=k)
+    return rs_sign(private_key=priv_key, msg_hash=msg_hash, seed=k)
 
 
 def verify_message_signature(


### PR DESCRIPTION
### Problem
The function message_signature() incorrectly calls rs_sign() with the argument `k`,  but rs_sign() does not accept `k` as a parameter. Instead, it expects `seed`.

### Fix
This PR updates message_signature() to correctly pass `seed` instead of `k` to rs_sign().  This ensures the function behaves as expected when signing messages.

This fix prevents potential runtime errors due to incorrect function arguments.

Optionally 'seed' value may be passed to the function with default value, as it realized in paradex.py library: 

def message_signature(msg_hash: int, priv_key: int, seed: int = 32) -> tuple[int, int]:
    """
    Signs the message with private key.
    """
    # `seed`: extra seed for additional entropy
    # `k`: is generated from `seed` by `starknet-crypto-py`
    # Ref: https://github.com/tradeparadex/starknet-crypto-py/blob/v0.2.0/src/lib.rs#L33
    return rs_sign(private_key=priv_key, msg_hash=msg_hash, seed=seed)